### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/src/rqt_gauges/my_plugin.cpp
+++ b/src/rqt_gauges/my_plugin.cpp
@@ -147,4 +147,4 @@ void triggerConfiguration()
 }*/
 
 } // namespace
-PLUGINLIB_DECLARE_CLASS(rqt_gauges, MyPlugin, rqt_gauges::MyPlugin, rqt_gui_cpp::Plugin)
+PLUGINLIB_EXPORT_CLASS(rqt_gauges::MyPlugin, rqt_gui_cpp::Plugin)


### PR DESCRIPTION
This macro, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)
